### PR TITLE
Dockerfile: upgrade packages to avoid fixed CVEs

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.8-slim-buster AS runner
 ARG TARGETARCH
+RUN apt-get update && apt-get upgrade -y
 RUN --mount=target=/tmp-mount \
     cp -a /tmp-mount/output_${TARGETARCH}/* /usr/local && \
     mkdir -p /etc/deepflow/  && \

--- a/app/Dockerfile_depends
+++ b/app/Dockerfile_depends
@@ -1,6 +1,7 @@
 # 构建层
 FROM python:3.8-slim-buster AS builder
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install --no-install-suggests \
     --no-install-recommends --yes \
     gcc \


### PR DESCRIPTION
Similar to deepflowio/deepflow#4451, packages should be upgraded.