### PR TITLE
fix tracing_completion_api

### DIFF
--- a/app/app/application/base.py
+++ b/app/app/application/base.py
@@ -1,6 +1,7 @@
 import uuid
 
 from data.status import Status
+from common.const import L7_FLOW_SIGNAL_SOURCE_OTEL
 
 # 0: unspecified, 1: internal, 2: server, 3: client, 4: producer, 5: consumer
 TAP_SIDE_BY_SPAN_KIND = {
@@ -24,12 +25,19 @@ class Base(object):
         self.region = self.args.get("region", None)
         self.signal_sources = self.args.get("signal_sources") or []
 
-    # Completing application span attribute information
     def complete_app_span(self, app_spans):
+        """
+        Fill application span attribute information
+        will be called in two scenario:
+        1. get external apm app spans
+        2. use tracing_completion api to fill sys spans & net spans
+        """
         for i, app_span in enumerate(app_spans):
             tap_side_by_span_kind = TAP_SIDE_BY_SPAN_KIND.get(
                 app_span.get('span_kind'))
             app_span["tap_side"] = tap_side_by_span_kind
+            # either external apm or tracing_completion should set this fixed value
+            app_span['signal_source'] = L7_FLOW_SIGNAL_SOURCE_OTEL
             app_span.pop("span_kind", None)
             for tag_int in [
                     "type", "req_tcp_seq", "resp_tcp_seq", "l7_protocol",

--- a/app/app/application/l7_flow_tracing.py
+++ b/app/app/application/l7_flow_tracing.py
@@ -10,7 +10,7 @@ from config import config
 from .base import Base
 from common import const
 from common.utils import curl_perform, inner_defaultdict_set
-from common.const import HTTP_OK
+from common.const import (HTTP_OK, L7_FLOW_SIGNAL_SOURCE_PACKET, L7_FLOW_SIGNAL_SOURCE_EBPF, L7_FLOW_SIGNAL_SOURCE_OTEL)
 from common.disjoint_set import DisjointSet
 from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
 
@@ -24,10 +24,6 @@ NET_SPAN_TAP_SIDE_PRIORITY = {
 L7_FLOW_TYPE_REQUEST = 0
 L7_FLOW_TYPE_RESPONSE = 1
 L7_FLOW_TYPE_SESSION = 2
-
-L7_FLOW_SIGNAL_SOURCE_PACKET = 0
-L7_FLOW_SIGNAL_SOURCE_EBPF = 3
-L7_FLOW_SIGNAL_SOURCE_OTEL = 4
 
 TAP_SIDE_CLIENT_PROCESS = 'c-p'
 TAP_SIDE_SERVER_PROCESS = 's-p'

--- a/app/app/common/const.py
+++ b/app/app/common/const.py
@@ -53,3 +53,8 @@ TAP_SIDE_RANKS = {
     TAP_SIDE_REST: 13,
     TAP_SIDE_LOCAL: 13,  # rest和local需要就近排列到其他位置上
 }
+
+# signal_source
+L7_FLOW_SIGNAL_SOURCE_PACKET = 0
+L7_FLOW_SIGNAL_SOURCE_EBPF = 3
+L7_FLOW_SIGNAL_SOURCE_OTEL = 4


### PR DESCRIPTION
modifications:
1. move `L7_FLOW_SIGNAL_SOURCE_XXX` from `l7_flow_tracing.py` to `common.const.py`
2. add `signal_source` for all tracing_completion import app_spans
3. fix `set_relate` in every `network`/`syscall`/`xrequestid` related map, use `set_all_relate` instead of it.

cherry-pick from #234 