### PR TITLE
[app] fix timeout config not working

### DIFF
--- a/app/app/app.py
+++ b/app/app/app.py
@@ -17,15 +17,17 @@ def signal_handler(sig, frame):
         log.info('Terminating Cleaner ...')
         sys.exit(0)
     elif sig == signal.SIGHUP:
-        log.info('Reloading statistics.yaml ...')
+        log.info('Reloading config.yaml ...')
         config.is_valid()
-        log.info('statistics.yaml reloaded.')
+        log.info('config.yaml reloaded.')
 
 
+@server.server.before_server_start
 async def notify_server_started(app, loop):
-    pass
+    server.init(app, config.http_request_timeout, config.http_response_timeout)
 
 
+@server.server.before_server_stop
 async def before_server_stop(app, loop):
     pass
 
@@ -40,11 +42,6 @@ def main():
     signal.signal(signal.SIGHUP, signal_handler)
 
     log.info('Launching Deepflow-app ...')
-    server.server.register_listener(notify_server_started,
-                                    'before_server_start')
-    server.server.register_listener(before_server_stop, 'before_server_stop')
-
-    server.init(config.http_request_timeout, config.http_response_timeout)
     try:
         sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
     except OSError:

--- a/app/app/server.py
+++ b/app/app/server.py
@@ -16,6 +16,10 @@ async def request_finished(request, response):
     pass
 
 
-def init(request_timeout, response_timeout):
-    server.config.REQUEST_TIMEOUT = request_timeout
-    server.config.RESPONSE_TIMEOUT = response_timeout
+def init(app: Sanic, request_timeout, response_timeout):
+    if app is None:
+        return
+    app.update_config({
+        "REQUEST_TIMEOUT": request_timeout,
+        "RESPONSE_TIMEOUT": response_timeout
+    })


### PR DESCRIPTION
- in current sanic version, `server.init` not working in multiple workers, we should init timeout config before every sanic worker app started
- after pr225 merged, open this