### PR TITLE
[app] optimize query

### DIFF
--- a/app/app.yaml
+++ b/app/app.yaml
@@ -8,6 +8,7 @@ app:
   # http request/response timeout
   http_request_timeout: 600
   http_response_timeout: 600
+  worker_numbers: 10
 
   querier:
     host: deepflow-server

--- a/app/app/app.py
+++ b/app/app/app.py
@@ -7,7 +7,6 @@ import sys
 import server
 from config import config
 from log import logger, sanic_logger
-from common.const import WORKER_NUMBER
 
 log = logger.getLogger(__name__)
 
@@ -47,7 +46,7 @@ def main():
     except OSError:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.bind(('', config.listen_port))
-    server.server.run(workers=WORKER_NUMBER,
+    server.server.run(workers=config.worker_numbers,
                       sock=sock,
                       protocol=sanic_logger.DFHttpProtocol)
 

--- a/app/app/common/const.py
+++ b/app/app/common/const.py
@@ -1,6 +1,5 @@
 
 # API
-WORKER_NUMBER = 10
 API_VERSION = 'v1'
 API_PREFIX = '/' + API_VERSION + '/stats'
 

--- a/app/app/config.py
+++ b/app/app/config.py
@@ -11,6 +11,7 @@ class Config(object):
     def parse_log(self, cfg):
         self.log_level = cfg.get('log-level', 'info')
         self.log_file = cfg.get('log-file', '/etc/deepflow/app.log')
+        self.worker_numbers = cfg.get('worker_numbers', 10)
 
     def parse_spec(self, cfg):
         spec = cfg.get('spec')


### PR DESCRIPTION
optimize query in `trace_l7_flows`
1. `worker_numbers` 修改为配置，避免在核心数 < 10 的机器上浪费调度能力
2. 移除 _id to _id_str 逻辑
3. 减少 `construct_from_dataframe` 调用，将 tcp_seq/syscall/x_request_id 的查询条件构造通过 dataframe column list 获取（理论上比逐行迭代快，但数据量少可能不明显）

- remove _id_str 测试结果:
测试集: `spans=18`, 迭代次数 4

| | Total Request Sent | Request/second | Avg Resp Time |
|--|--|--|--|
| before(v6.5.8) | 395 | 1.29 | 2,625ms |
| after - 2 | 477 | 1.56 | 2,028ms |

再增加 3 修改后的测试结果：（吞吐差异不明显，但平均时延有提升）
| | Total Request Sent | Request/second | Avg Resp Time |
|--|--|--|--|
| after - 3 | 478 | 1.56 | 1,985 ms |

另一个测试集：`spans=79`，迭代次数 23

| | Total Request Sent | Request/second | Avg Resp Time |
|--|--|--|--|
| before(v6.5.8) | 75 | 0.24 | 17,792ms |
| after - 2&3 | 133 | 0.43 | 10,006 ms |