### PR TITLE
[app] fix when auto_service_id is zero

### DIFF
--- a/app/app/application/l7_flow_tracing.py
+++ b/app/app/application/l7_flow_tracing.py
@@ -2574,6 +2574,9 @@ def merge_service(services: List[ProcessSpanSet], traces: list,
         elif service.app_service:
             service_uid = f"-{service.app_service}"
             service_uname = service.app_service
+        elif service.ip:
+            service_uid = f"{service.ip}-"
+            service_uname = service.ip
         else:
             service_uid = 'unknown-'
             service_uname = "unknown service"


### PR DESCRIPTION
when get auto_service_id = 0, should show `ip` as `auto_service`