### PR TITLE
feat: add l7_protocol enum value

### DIFF
--- a/app/app/application/l7_flow_tracing.py
+++ b/app/app/application/l7_flow_tracing.py
@@ -55,6 +55,7 @@ RETURN_FIELDS = list(
         # 追踪Meta信息
         "signal_source",
         "l7_protocol",
+        "Enum(l7_protocol)",
         "l7_protocol_str",
         "type",
         "req_tcp_seq",
@@ -2789,6 +2790,8 @@ def _get_flow_dict(flow: DataFrame):
         flow.get("Enum(tap_side)"),
         "l7_protocol":
         flow["l7_protocol"],
+        "Enum(l7_protocol)":
+        flow.get("Enum(l7_protocol)"),
         "l7_protocol_str":
         flow["l7_protocol_str"],
         "endpoint":


### PR DESCRIPTION
- add l7_protocol enum value for front-end

issue: found that `l7_protocol_str` in some case is different from `Enum(l7_protocol)`
real data store in Clickhouse:

```text
┌─l7_protocol─┬─l7_protocol_str─┐
│           0 │                 │
│          20 │ HTTP_TLS        │
│          20 │ http            │
│          20 │ HTTP            │
│          21 │ HTTP2           │
│          21 │ HTTP2_TLS       │
│          41 │ gRPC            │
│          60 │ MySQL           │
│          61 │ PostgreSQL      │
│          80 │ Redis           │
│         102 │ AMQP            │
│         120 │ DNS             │
│         121 │ TLS             │
└─────────────┴─────────────────┘
```