### PR TITLE
fix: enhance process connection

### DIFF
--- a/app/app/application/l7_flow_tracing.py
+++ b/app/app/application/l7_flow_tracing.py
@@ -1368,6 +1368,9 @@ class SpanNode:
     def get_request_id(self) -> int:
         return self.flow.get('request_id', 0)
 
+    def get_response_duration(self) -> int:
+        return self.flow.get('response_duration', 0)
+
     def time_range_cover(self, other_sys_span: 'SpanNode') -> bool:
         return self.flow['start_time_us'] <= other_sys_span.flow[
             'start_time_us'] and self.flow[
@@ -2275,6 +2278,7 @@ def _connect_process_and_networks(process_roots: List[SpanNode],
         # 避免子循环多次访问字典
         ps_index = ps_parent.get_flow_index()
         ps_span_id = ps_parent.get_span_id()
+        ps_response_duration = ps_parent.get_response_duration() 
         for net_child in network_roots:
             if net_child.get_parent_id() >= 0:
                 continue
@@ -2284,6 +2288,12 @@ def _connect_process_and_networks(process_roots: List[SpanNode],
                 continue
             if net_child.agent_id == ps_parent.agent_id and not ps_parent.time_range_cover(net_child):
                 # 对同一个主机采集到的数据，不存在时差
+                continue
+            if net_child.signal_source != L7_FLOW_SIGNAL_SOURCE_OTEL and ps_parent.signal_source!= L7_FLOW_SIGNAL_SOURCE_OTEL and \
+                  net_child.get_response_duration() and ps_response_duration < net_child.get_response_duration():
+                # 如果能取到响应时长（请求响应完整），需要判断响应时长覆盖
+                # 由于 app span 的时长是在 sdk 中统计，如果发生子 span 异步完成，父 span 提前完成，子 span 时间可以大于父 span 
+                # 所以这里判断 response_duration 忽略 OTEL signal_source
                 continue
             if ps_index == net_child.get_flow_index():
                 # 共享一个 c-p, net_child parent == ps_parent 的 parent
@@ -2300,6 +2310,7 @@ def _connect_process_and_networks(process_roots: List[SpanNode],
         ps_index = ps_child.get_flow_index()
         ps_child_span_id = ps_child.get_span_id()
         ps_child_parent_span_id = ps_child.get_parent_span_id()
+        ps_child_response_duration = ps_child.get_response_duration()
         for net_parent in network_leafs:
             if ps_child.get_parent_id() >= 0:
                 continue
@@ -2307,6 +2318,9 @@ def _connect_process_and_networks(process_roots: List[SpanNode],
                 or _same_span_set(ps_child, net_parent, 'process_span_set'):
                 continue
             if ps_child.agent_id == net_parent.agent_id and not net_parent.time_range_cover(ps_child):
+                continue
+            if net_parent.signal_source != L7_FLOW_SIGNAL_SOURCE_OTEL and ps_child.signal_source!= L7_FLOW_SIGNAL_SOURCE_OTEL and \
+                net_parent.get_response_duration() and net_parent.get_response_duration() < ps_child_response_duration:
                 continue
             if ps_index == net_parent.get_flow_index():
                 # 共享一个 s-p，则 ps_child 的 parent == net_parent 的 parent
@@ -2335,6 +2349,7 @@ def _connect_process_and_networks(process_roots: List[SpanNode],
         ps_child_index = ps_child.get_flow_index()
         ps_child_span_id = ps_child.get_span_id()
         ps_child_parent_span_id = ps_child.get_parent_span_id()
+        ps_child_response_duration = ps_child.get_response_duration()
         for ps_parent in process_leafs:
             if ps_child.get_parent_id() >= 0:
                 continue
@@ -2342,6 +2357,9 @@ def _connect_process_and_networks(process_roots: List[SpanNode],
                 or _same_span_set(ps_child, ps_parent, 'process_span_set'):
                 continue
             if ps_child.agent_id == ps_parent.agent_id and not ps_parent.time_range_cover(ps_child):
+                continue
+            if ps_parent.signal_source != L7_FLOW_SIGNAL_SOURCE_OTEL and ps_child.signal_source!= L7_FLOW_SIGNAL_SOURCE_OTEL and \
+                ps_parent.get_response_duration() and ps_parent.get_response_duration() < ps_child_response_duration:
                 continue
             if ps_child_index == ps_parent.get_flow_index():
                 # 共享一个 c-p，则 ps_child 的 parent == ps_parent 的 parent
@@ -2395,7 +2413,7 @@ def _connect_process_and_networks(process_roots: List[SpanNode],
         net_child_x_request_id_1 = net_child.get_x_request_id_1()
         net_child_request_id = net_child.get_request_id()
         net_child_l7_protocol = net_child.flow['l7_protocol']
-        net_child_response_duration = net_child.flow['response_duration']
+        net_child_response_duration = net_child.get_response_duration()
         for net_parent in network_leafs:
             if net_child.get_parent_id() >= 0:
                 continue
@@ -2421,8 +2439,7 @@ def _connect_process_and_networks(process_roots: List[SpanNode],
                 # 网关透传 x_request_id 或透传 http header 中的 span_id
                 # 要求 parent 的所有 response_duration > child 最大的 response_duration
                 # 由于 network span set 内是按 c 端 agent 在前+ start_time 排序的，可以认为 net_child(root) 就是一组内时延最大的
-                if net_parent.flow[
-                        'response_duration'] < net_child_response_duration:
+                if net_parent.get_response_duration() < net_child_response_duration:
                     continue
                 else:
                     # 这里不要直接设置 parent，如果找到了满足条件的情况，都加入列表待处理
@@ -2433,15 +2450,15 @@ def _connect_process_and_networks(process_roots: List[SpanNode],
                         # 根据 `时延最接近` 原则找 parent
                         # 即在满足条件的 parent 里找到时延最接近最小的 net_parent，它更有可能是直接的 `上一跳`
                         # network_match_parent[net_child_index] 指向 net_parent 的 _index，从 flow_index_to_span 中取 response_duration
-                        if flow_index_to_span[network_match_parent[net_child_index]].flow['response_duration'] \
-                            > net_parent.flow['response_duration']:
+                        if flow_index_to_span[network_match_parent[net_child_index]].get_response_duration() \
+                            > net_parent.get_response_duration():
                             network_match_parent[
                                 net_child_index] = net_parent.get_flow_index()
 
             elif net_child_request_id and net_child_request_id == net_parent.get_request_id() \
                 and net_child_l7_protocol in [L7_PROTOCOL_HTTP2, L7_PROTOCOL_GRPC] \
                     and net_child_l7_protocol == net_parent.flow['l7_protocol'] \
-                        and net_child_response_duration <= net_parent.flow['response_duration']:
+                        and net_child_response_duration <= net_parent.get_response_duration():
                 # grpc protocol: request_id get from `stream_id`, means different network_span_set share same stream, it should be connected
                 # but other protocol may re-use request_id, so only support grpc now
                 # net_child.response_duration <= net_parent.response_duration for case both duration is 0


### PR DESCRIPTION
- When do ProcessSpanSet connection , we need to enhance `response_duration` condition, force `parent`'s response_duration must greater than childs' response_duration .( when both can get a value greater than 0)

- but, for OTEL span, response_duration was calculated by APM sdk, when child span completion in async thread and parent span complete before child, it may cause child's response_duration greater than parent's response_duration, so I ignore OTEL singal source for `response_duration` limitation.