### PR TITLE
chore: bump aiohttp to 3.10.2

### DIFF
--- a/app/Dockerfile_depends
+++ b/app/Dockerfile_depends
@@ -20,7 +20,7 @@ RUN pip install cffi
 FROM builder-base AS builder-custom
 RUN pip install --user  --disable-pip-version-check \
      	 --no-cache-dir \
-         aiofiles==23.2.1 aiohttp==3.9.5 aiosignal==1.3.1 async-timeout==4.0.3 attrs==23.1.0 \
+         aiofiles==23.2.1 aiohttp==3.10.2 aiosignal==1.3.1 async-timeout==4.0.3 attrs==23.1.0 \
          Deprecated==1.2.14 frozenlist==1.4.0 html5tagger==1.3.0 httptools==0.6.1 \
          idna==3.7 importlib-metadata==6.8.0 multidict==6.0.4 numpy==1.24.4 \
          opentelemetry-api==1.21.0 opentelemetry-sdk==1.21.0 opentelemetry-semantic-conventions==0.42b0 \


### PR DESCRIPTION
Fixes CVE-2024-42367.