### PR TITLE
feat: set max_iteration only query trace_id data when is 0

### DIFF
--- a/app/app/application/l7_flow_tracing.py
+++ b/app/app/application/l7_flow_tracing.py
@@ -248,6 +248,12 @@ class L7FlowTracing(Base):
                 if trace_id:
                     allowed_trace_ids.add(trace_id)
                     new_trace_ids_in_prev_iteration.add(trace_id)
+                
+        # max_iterations set to 0 means only query data with trace_id
+        only_query_trace_id = False
+        if max_iteration == 0:
+            max_iteration = 1
+            only_query_trace_id = True
 
         # 进行迭代查询，上限为 config.spec.max_iteration
         for i in range(max_iteration):
@@ -323,6 +329,8 @@ class L7FlowTracing(Base):
                 pass
 
             if only_query_app_spans:  # no more iterations needed
+                break
+            if only_query_trace_id:  # no more iterations needed
                 break
 
             # 2. Query by tcp_seq / syscall_trace_id / x_request_id

--- a/app/app/models/models.py
+++ b/app/app/models/models.py
@@ -21,7 +21,7 @@ class FlowLogL7Tracing(Model):
     debug = BooleanType(serialized_name="DEBUG", required=False)
     max_iteration = IntType(serialized_name="MAX_ITERATION",
                             required=False,
-                            min_value=1,
+                            min_value=0,
                             default=config.max_iteration)
     network_delay_us = IntType(serialized_name="NETWORK_DELAY_US",
                                required=False,


### PR DESCRIPTION
allow `MAX_ITERATION` set to 0, when it's 0, means only query data with trace_id