### PR TITLE
feat: optimize connect_process_and_networks

### DIFF
--- a/app/app/application/tracing_completion.py
+++ b/app/app/application/tracing_completion.py
@@ -3,7 +3,7 @@ from log import logger
 
 from .l7_flow_tracing import (L7_FLOW_RELATIONSHIP_SPAN_ID)
 from .l7_flow_tracing import (L7FlowTracing)
-from common.utils import inner_defaultdict_set
+from common.utils import inner_defaultdict_int
 
 log = logger.getLogger(__name__)
 
@@ -42,13 +42,12 @@ class TracingCompletion(L7FlowTracing):
                 break
         self.args._id = app_span_id  # set app_span_id as args, make it never been pruning
         # build related_map inside app_spans
-        related_map_from_api = defaultdict(inner_defaultdict_set)
+        related_map_from_api = defaultdict(inner_defaultdict_int)
         for i in range(len(self.app_spans)):
             for j in range(len(self.app_spans)):
                 if i == j:
                     continue
-                related_map_from_api[self.app_spans[i]['_id']][
-                    self.app_spans[j]['_id']].add(L7_FLOW_RELATIONSHIP_SPAN_ID)
+                related_map_from_api[self.app_spans[i]['_id']][self.app_spans[j]['_id']] |= L7_FLOW_RELATIONSHIP_SPAN_ID
         rst = await self.trace_l7_flow(
             time_filter,
             base_filter,

--- a/app/app/common/utils.py
+++ b/app/app/common/utils.py
@@ -139,3 +139,6 @@ def app_exception(function):
 
 def inner_defaultdict_set():
     return defaultdict(set)
+
+def inner_defaultdict_int():
+    return defaultdict(int)


### PR DESCRIPTION
- optimze `connect_process_and_networks` func cost
1. use `related_flow_index_map` to optimize O(n^2) loop scan
2. use single `_id IN(x)` instead of `_id IN(xx) and _id IN(xx)` to optimize query performance
3. use bit calculation instead of string array for `related_types`

---
- 优化 `connect_process_and_networks` 函数
1. 使用`related_flow_index_map` 来优化原有的 O(n^2) 扫描，减少扫描量
2. 使用一个单一的 `_id in (xx)` 而不是多个 `_id in (xx) and _id in (xx)` 来提升查询效果
3. 计算 related_types 时，使用位运算取代原有的字符串数组实现