### PR TITLE
Dockerfile: bump python to 3.12

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine AS runner
+FROM python:3.12-alpine AS runner
 ARG TARGETARCH
 RUN apk update && apk upgrade
 RUN pip install --upgrade --disable-pip-version-check --no-cache-dir pip setuptools

--- a/app/Dockerfile_depends
+++ b/app/Dockerfile_depends
@@ -1,5 +1,5 @@
 # 构建层
-FROM python:3.8-alpine AS builder
+FROM python:3.12-alpine AS builder
 RUN apk update && \
     apk upgrade && \
     apk add --no-cache \


### PR DESCRIPTION
Python 3.8 has reached its EOL.

[Status of Python versions](https://devguide.python.org/versions/)