### PR TITLE
feat: allow query by region

### DIFF
--- a/app/app/application/l7_flow_tracing.py
+++ b/app/app/application/l7_flow_tracing.py
@@ -631,7 +631,7 @@ class L7FlowTracing(Base):
         querier = Querier(to_dataframe=True,
                           debug=self.args.debug,
                           headers=self.headers)
-        response = await querier.exec_all_clusters(DATABASE, sql)
+        response = await querier.exec_all_clusters(DATABASE, sql, self.region)
         '''
         database = 'flow_log'  # database
         host = '10.1.20.22'  # ck ip


### PR DESCRIPTION
- 之前的代码里 exec_all_cluster region 参数没有生效，默认查询了所有节点
- 修改为主动传入 region 参数使它生效 ( 当不传递 region 时，即为查询所有 region）