### PR TITLE
fix: v7.0 use github.ref_name as cache tag

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -63,8 +63,8 @@ jobs:
           file: app/Dockerfile_depends
           platforms: linux/amd64
           outputs: type=local,dest=./app/output_amd64
-          cache-from: type=registry,mode=max,ref=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:main-cache-amd64
-          cache-to: type=registry,mode=max,ref=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:main-cache-amd64
+          cache-from: type=registry,mode=max,ref=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:${{ github.ref_name }}-cache-amd64
+          cache-to: type=registry,mode=max,ref=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:${{ github.ref_name }}-cache-amd64
 
       - name: Package code build results
         run: |
@@ -116,8 +116,8 @@ jobs:
           file: app/Dockerfile_depends
           platforms: linux/arm64
           outputs: type=local,dest=./app/output_arm64
-          cache-from: type=registry,mode=max,ref=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:main-cache-arm64
-          cache-to: type=registry,mode=max,ref=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:main-cache-arm64
+          cache-from: type=registry,mode=max,ref=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:${{ github.ref_name }}-cache-arm64
+          cache-to: type=registry,mode=max,ref=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:${{ github.ref_name }}-cache-arm64
 
       - name: Package code build results
         run: |


### PR DESCRIPTION
由于 v7.0 依旧使用 debian 做基础镜像，没有打包速度的问题，直接用分支名做基础缓存即可